### PR TITLE
Validate powercap after scaling

### DIFF
--- a/cudampilib/cudampicommon.c
+++ b/cudampilib/cudampicommon.c
@@ -21,10 +21,10 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OU
 #define MPI_LOGGING
 #include "logger.h"
 
-float computeDevPerformance(struct timeval period) {
+float computeDevPerformance(double period_us) {
   // period is just the time between two events so compute performance as an inverse
 
-  return 1000000.0 / (period.tv_sec * 1000000 + period.tv_usec);
+  return 1000000.0 / period_us;
 }
 
 float getGPUpower(int gpuid) {

--- a/cudampilib/cudampilib.c
+++ b/cudampilib/cudampilib.c
@@ -239,30 +239,25 @@ void __cudampi__scaleCpuBatchSize() {
       // Scale cpu batch size by:
       // scalingFactor = gpuBatchTimePerBatch / cpuBatchTimePerBatch
       double scalingFactor = (__cudampi__firstIterTotalGpuBatchTimeSeconds / __cudampi__firstIterTotalGpuBatches) / (__cudampi__firstIterTotalCpuBatchTimeSeconds / __cudampi__firstIterTotalCpuBatches);
-      // TODO: See if its better to scale from actual CPU value or from default
-      long long newCpuBatchSize = (long long)((double)(__cudampi__default_batch_size)*scalingFactor);
 
-      // Make sure that newCpuBatchSize is between 0 and ULONG_MAX. Also assume that CPU batch size can be at most 2x larger than GPU
-      if (newCpuBatchSize < 1) {
-        newCpuBatchSize = 1;
-      } else {
-        if (newCpuBatchSize > (2 * ((long long)__cudampi__cpu_batch_size))) {
-          newCpuBatchSize = 2 * ((long long)__cudampi__cpu_batch_size);
+      // Don't scale cpu batch size up as it would exceed allocated buffers
+      if (scalingFactor < 1) {
+        long long newCpuBatchSize = (long long)((double)(__cudampi__default_batch_size)*scalingFactor);
+
+        // Make sure that at least one batch is delegated to CPU
+        if (newCpuBatchSize < 1) {
+          newCpuBatchSize = 1;
         }
 
-        if (newCpuBatchSize >= ULONG_MAX) {
-          newCpuBatchSize = ULONG_MAX - 1;
-        }
+        #pragma omp atomic write
+        __cudampi__cpu_batch_size = (unsigned long)newCpuBatchSize;
+
+        log_message(LOG_INFO, "Scaling CPU batch size by %lf (new value: %lld)", scalingFactor, newCpuBatchSize);
       }
-
-      #pragma omp atomic write
-      __cudampi__cpu_batch_size = (unsigned long)newCpuBatchSize;
 
       // Atomic because other threads might be reading it
       #pragma omp atomic write
       __cudampi__cpuBatchSizeScalingDone = 1;
-
-      log_message(LOG_INFO, "Scaling CPU batch size by %lf (new value: %lld)", scalingFactor, newCpuBatchSize);
     }
   }
 }

--- a/cudampilib/cudampilib.c
+++ b/cudampilib/cudampilib.c
@@ -491,21 +491,29 @@ int __cudampi__selectdevicesforpowerlimit_greedy() { // adopts a greedy strategy
       
       float inverseDeviceEnergyUsed = computeDevPerformance(__cudampi__time_us[i]) / __cudampi__devicepower[i];
       if (((-1) == (__cudampi__deviceenabled[__cudampi__currentdevice[i]])) && (__cudampi__devicepower[__cudampi__currentdevice[i]] <= powerleft) &&
-          (inverseDeviceEnergyUsed > curperfpower)) {
-        curperfpower = inverseDeviceEnergyUsed;
-        indexselected = i;
-        anydeviceenabled = 1;
+        (inverseDeviceEnergyUsed > curperfpower)) {
+      curperfpower = inverseDeviceEnergyUsed;
+      indexselected = i;
+      anydeviceenabled = 1;
       }
     }
     if (indexselected != (-1)) {
       // enable the found device now
       __cudampi__deviceenabled[__cudampi__currentdevice[indexselected]] = 1;
       if (!managerselected) {
-        managerselected = 1;
-        __cudampi__amimanager[__cudampi__currentdevice[indexselected]] = 1;
+      managerselected = 1;
+      __cudampi__amimanager[__cudampi__currentdevice[indexselected]] = 1;
       }
+      
+      // Log if the selected device is CPU or GPU and how much power it subtracts
+      if (__cudampi__currentdevice[indexselected] >= __cudampi_totalgpudevicecount) {
+      log_message(LOG_INFO, "Selected CPU device %d, subtracted power: %f, inverse device energy used: %f", __cudampi__currentdevice[indexselected], __cudampi__devicepower[__cudampi__currentdevice[indexselected]], curperfpower);
+      } else {
+      log_message(LOG_INFO, "Selected GPU device %d, subtracted power: %f, inverse device energy used: %f", __cudampi__currentdevice[indexselected], __cudampi__devicepower[__cudampi__currentdevice[indexselected]], curperfpower);
+      }
+      
       powerleft -= __cudampi__devicepower[__cudampi__currentdevice[indexselected]];
-      log_message(LOG_DEBUG,"\nSelected device %d", __cudampi__currentdevice[indexselected]);
+      log_message(LOG_INFO, "Remaining power left: %f", powerleft);
     }
   } while (indexselected != (-1));
   fflush(stdout);
@@ -521,6 +529,11 @@ int __cudampi__selectdevicesforpowerlimit_greedy() { // adopts a greedy strategy
     if (__cudampi__deviceenabled[__cudampi__currentdevice[i]] != 1) {
       __cudampi__deviceenabled[__cudampi__currentdevice[i]] = 0;
     }
+  }
+
+  // Check if all devices are selected and there is still power left
+  if (powerleft > 0) {
+    log_message(LOG_INFO, "All devices are selected and there is still power left: %f", powerleft);
   }
 
   // unlock the devices' locks
@@ -682,7 +695,7 @@ void __cudampi__initializeMPI(int argc, char **argv) {
   }
 
   if (__cudampi__arguments.powercap > 0) {
-    log_message(LOG_INFO, "\nSetting power limit=%f\n", __cudampi__arguments.powercap);
+    log_message(LOG_INFO, "\nSetting power limit=%d\n", __cudampi__arguments.powercap);
     __cudampi__setglobalpowerlimit(__cudampi__arguments.powercap);
   }
 

--- a/cudampilib/cudampilib.c
+++ b/cudampilib/cudampilib.c
@@ -18,7 +18,6 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OU
 #include <nvml.h>
 #include <omp.h>
 
-//#define PROFILE_BATCHES
 #define ENABLE_LOGGING
 #define MPI_LOGGING
 #include "logger.h"
@@ -67,7 +66,7 @@ int __cudampi__currentdevice[__CUDAMPI_MAX_THREAD_COUNT]; // current device id f
 
 struct timeval __cudampi__timestart[__CUDAMPI_MAX_THREAD_COUNT]; // start of time measurement
 struct timeval __cudampi__timestop[__CUDAMPI_MAX_THREAD_COUNT];  // end of time measurement
-struct timeval __cudampi__time[__CUDAMPI_MAX_THREAD_COUNT];      // last time measurement (from start to stop)
+double __cudampi__time_us[__CUDAMPI_MAX_THREAD_COUNT];      // last time measurement (from start to stop)
 int __cudampi__timemeasured[__CUDAMPI_MAX_THREAD_COUNT] = {0};   // whether time measurement started
 float __cudampi__devicepower[__CUDAMPI_MAX_THREAD_COUNT];        // current power taken by a device
 
@@ -86,10 +85,10 @@ float __cudampi__globalpowerlimit;
 
 int powermeasurecounter[__CUDAMPI_MAX_THREAD_COUNT] = {0};
 
-#ifdef PROFILE_BATCHES
 unsigned long __cudampi__batches_sent[__CUDAMPI_MAX_THREAD_COUNT] = {0};
 unsigned long long __cudampi__data_points_sent[__CUDAMPI_MAX_THREAD_COUNT] = {0};
-#endif
+unsigned long __cudampi__last_batches_sent[__CUDAMPI_MAX_THREAD_COUNT] = {0};
+unsigned long long __cudampi__last_data_points_sent[__CUDAMPI_MAX_THREAD_COUNT] = {0};
 
 unsigned long __cudampi__default_batch_size;
 unsigned long __cudampi__cpu_batch_size;
@@ -490,7 +489,7 @@ int __cudampi__selectdevicesforpowerlimit_greedy() { // adopts a greedy strategy
     indexselected = -1;
     for (i = 0; i < __cudampi_totaldevicecount; i++) {
       
-      float inverseDeviceEnergyUsed = computeDevPerformance(__cudampi__time[i]) / __cudampi__devicepower[i];
+      float inverseDeviceEnergyUsed = computeDevPerformance(__cudampi__time_us[i]) / __cudampi__devicepower[i];
       if (((-1) == (__cudampi__deviceenabled[__cudampi__currentdevice[i]])) && (__cudampi__devicepower[__cudampi__currentdevice[i]] <= powerleft) &&
           (inverseDeviceEnergyUsed > curperfpower)) {
         curperfpower = inverseDeviceEnergyUsed;
@@ -564,10 +563,8 @@ __cudampi__batch_pointer __cudampi__getnextchunkindex_enableddevices(long long *
     if (batch_pointer.start < max)
     {
       batch_pointer.n_elements = (((batch_pointer.start + batchsize) > max )? max - batch_pointer.start : batchsize);
-      #ifdef PROFILE_BATCHES
       __cudampi__batches_sent[omp_get_thread_num()] += 1;
       __cudampi__data_points_sent[omp_get_thread_num()] += batchsize;
-      #endif
     }
   }
 
@@ -591,10 +588,8 @@ __cudampi__batch_pointer __cudampi__getnextchunkindex_alldevices(long long *glob
     if (batch_pointer.start < max)
     {
       batch_pointer.n_elements = (((batch_pointer.start + batchsize) > max )? max - batch_pointer.start : batchsize);
-      #ifdef PROFILE_BATCHES
       __cudampi__batches_sent[omp_get_thread_num()] += 1;
       __cudampi__data_points_sent[omp_get_thread_num()] += batchsize;
-      #endif
     }
 
   return batch_pointer;
@@ -850,12 +845,10 @@ void __cudampi__initializeMPI(int argc, char **argv) {
 
 void __cudampi__terminateMPI() {
 
-  #ifdef PROFILE_BATCHES
   for (int i = 0; i < __cudampi_totaldevicecount;i++){
     log_message(LOG_INFO, "Batches sent by thread %d: %ld", i, __cudampi__batches_sent[i]);
     log_message(LOG_INFO, "Data points processed by thread %d: %lld", i, __cudampi__data_points_sent[i]);
   }
-  #endif
 
   // finalize the other nodes -> shut down threads responsible for remote GPUs
 
@@ -1079,25 +1072,43 @@ cudaError_t __cudampi__deviceSynchronize(void) {
 
   // record time
   if (__cudampi__timemeasured[__cudampi__currentDevice]) {
+    omp_set_lock(&(__cudampi__devicelocks[__cudampi__currentDevice]));
+    struct timeval elapsed_time;
     gettimeofday(&(__cudampi__timestop[__cudampi__currentDevice]), NULL);
 
-    omp_set_lock(&(__cudampi__devicelocks[__cudampi__currentDevice]));
-    __cudampi__time[__cudampi__currentDevice].tv_sec = __cudampi__timestop[__cudampi__currentDevice].tv_sec - __cudampi__timestart[__cudampi__currentDevice].tv_sec;    // compute current time
-    __cudampi__time[__cudampi__currentDevice].tv_usec = __cudampi__timestop[__cudampi__currentDevice].tv_usec - __cudampi__timestart[__cudampi__currentDevice].tv_usec; // compute current time
-    struct timeval elapsed_time = __cudampi__time[__cudampi__currentDevice];
-    double time_in_seconds = elapsed_time.tv_sec + elapsed_time.tv_usec / 1000000.0;
-    omp_unset_lock(&(__cudampi__devicelocks[__cudampi__currentDevice]));
+    // Compute time elapsed
+    elapsed_time.tv_sec = __cudampi__timestop[__cudampi__currentDevice].tv_sec - __cudampi__timestart[__cudampi__currentDevice].tv_sec; 
+    elapsed_time.tv_usec = __cudampi__timestop[__cudampi__currentDevice].tv_usec - __cudampi__timestart[__cudampi__currentDevice].tv_usec;
 
     __cudampi__timestart[__cudampi__currentDevice] = __cudampi__timestop[__cudampi__currentDevice];
+
+    // Convert to seconds and microseconds
+    __cudampi__time_us[__cudampi__currentDevice] = elapsed_time.tv_sec * 1000000 + elapsed_time.tv_usec;
+    double time_in_seconds = __cudampi__time_us[__cudampi__currentDevice] / 1000000.0;
+
+    // Count batches sent from last iteration
+    unsigned long batches_sent = __cudampi__batches_sent[__cudampi__currentDevice] - __cudampi__last_batches_sent[__cudampi__currentDevice];
+    unsigned long long data_points_sent = __cudampi__data_points_sent[__cudampi__currentDevice] - __cudampi__last_data_points_sent[__cudampi__currentDevice];
+    __cudampi__last_batches_sent[__cudampi__currentDevice] = __cudampi__batches_sent[__cudampi__currentDevice];
+    __cudampi__last_data_points_sent[__cudampi__currentDevice] = __cudampi__data_points_sent[__cudampi__currentDevice];
+
+    double scaling_factor = 1;
+    if (batches_sent > 0) {
+      scaling_factor = ((double)data_points_sent) / ((double)(batches_sent * __cudampi__default_batch_size));
+    }
+
+    log_message(LOG_DEBUG, "Scaling factor for power capping = %lf", scaling_factor);
+
+    // Divide time by scaling factor (which is smaller than 1) which means that
+    // if batch size for that device was scaled down, time it would take to process full batch of data is calculated
+    __cudampi__time_us[__cudampi__currentDevice] /= scaling_factor;
 
     if (__cudampi__isCpu() && (energy != -1)){
       power = energy / time_in_seconds;
     }
 
     if (power != (-1)) {
-      omp_set_lock(&(__cudampi__devicelocks[__cudampi__currentDevice]));
       __cudampi__devicepower[__cudampi__currentDevice] = power;
-      omp_unset_lock(&(__cudampi__devicelocks[__cudampi__currentDevice]));
       
       log_message(LOG_DEBUG, "Got power %f with time in seconds = %f", power, time_in_seconds);
       #pragma omp atomic
@@ -1113,6 +1124,8 @@ cudaError_t __cudampi__deviceSynchronize(void) {
       __cudampi__finishDeviceStatsMeasurement(time_in_seconds);
       __cudampi__scaleCpuBatchSize();
     }
+
+    omp_unset_lock(&(__cudampi__devicelocks[__cudampi__currentDevice]));
   } else {
     __cudampi__timemeasured[__cudampi__currentDevice] = 1;
     gettimeofday(&(__cudampi__timestart[__cudampi__currentDevice]), NULL);

--- a/cudampilib/include/cudampicommon.h
+++ b/cudampilib/include/cudampicommon.h
@@ -15,7 +15,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OU
 #include <omp.h>
 #include <string.h>
 
-float computeDevPerformance(struct timeval period);
+float computeDevPerformance(double period_us);
 
 float getGPUpower(int gpuid);
 


### PR DESCRIPTION
After scaling CPU time according to number of batches processed, only GPUs are choosen for powercap:
```
s184297@des06:~/parallel-processing-cpu-and-gpu-env-and-lib-with-powercap/cudampilib$ ./run_scripts/run-app vecadd B 15 --cpu-enabled=1 --number-of-streams=2   --batch-size=3200 --powercap=300 --problem-size=320000000 --initial-cpu-batch-size-scaling 5
All arguments provided:
=====================================
APP_NAME: 'vecadd'
MODE: 'B'
=====================================
MACHINES COUNT: '15'
SLAVE_PROC_AMOUNT: '14'
=====================================
Running master on des01 and slaves on des (2 - 15)
Running remotely with application 'vecadd'...
Command: mpirun --mca orte_keep_fqdn_hostnames t --mca btl_tcp_if_exclude docker0,docker_gwbridge,lo,vboxnet0 --bind-to none --machinefile "./temp_hostfile" -np 1 ./build/app-streams-vecadd --cpu-enabled=1 --number-of-streams=2 --batch-size=3200 --powercap=300 --problem-size=320000000 --initial-cpu-batch-size-scaling 5 : -np 14 ./build/cudampislave-vecadd
=====================================
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:25] [INFO] CPU Enabled                                : 1
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:25] [INFO] Number of Streams                          : 2
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:25] [INFO] Batch Size                                 : 3200
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:25] [INFO] Power Cap                                  : 300
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:25] [INFO] Problem Size                               : 320000000
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:25] [INFO] Initial Cpu Batch Size Scaling Factor      : 5
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:25] [INFO] Dynamic CPU Batch Size Scaling Enabled     : 1
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:25] [INFO] Scaled CPU batch size down to 640 from 3200 (factor of 5)
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:25] [INFO] 
Setting power limit=300

[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:25] [INFO] 
On node 0 using 1 GPUs.
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:25] [INFO] 
On node 0 using 0 CPU threads.

[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:25] [INFO] 
On node 1 using 1 GPUs.
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:25] [INFO] 
On node 1 using 23 CPU threads.

[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:25] [INFO] 
On node 2 using 1 GPUs.
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:25] [INFO] 
On node 2 using 23 CPU threads.

[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:25] [INFO] 
On node 3 using 1 GPUs.
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:25] [INFO] 
On node 3 using 23 CPU threads.

[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:25] [INFO] 
On node 4 using 1 GPUs.
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:25] [INFO] 
On node 4 using 23 CPU threads.

[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:25] [INFO] 
On node 5 using 1 GPUs.
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:25] [INFO] 
On node 5 using 23 CPU threads.

[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:25] [INFO] 
On node 6 using 1 GPUs.
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:25] [INFO] 
On node 6 using 23 CPU threads.

[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:25] [INFO] 
On node 7 using 1 GPUs.
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:25] [INFO] 
On node 7 using 23 CPU threads.

[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:25] [INFO] 
On node 8 using 1 GPUs.
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:25] [INFO] 
On node 8 using 23 CPU threads.

[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:25] [INFO] 
On node 9 using 1 GPUs.
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:25] [INFO] 
On node 9 using 23 CPU threads.

[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:25] [INFO] 
On node 10 using 1 GPUs.
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:25] [INFO] 
On node 10 using 23 CPU threads.

[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:25] [INFO] 
On node 11 using 1 GPUs.
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:25] [INFO] 
On node 11 using 23 CPU threads.

[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:25] [INFO] 
On node 12 using 1 GPUs.
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:25] [INFO] 
On node 12 using 23 CPU threads.

[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:25] [INFO] 
On node 13 using 1 GPUs.
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:25] [INFO] 
On node 13 using 23 CPU threads.

[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:25] [INFO] 
On node 14 using 1 GPUs.
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:25] [INFO] 
On node 14 using 23 CPU threads.

[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:27] [INFO] Selected GPU device 0, subtracted power: 39.936001, inverse device energy used: 676.758484
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:27] [INFO] Remaining power left: 260.063995
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:27] [INFO] Selected GPU device 9, subtracted power: 38.000999, inverse device energy used: 20.526596
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:27] [INFO] Remaining power left: 222.062988
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:27] [INFO] Selected GPU device 8, subtracted power: 38.237999, inverse device energy used: 17.296293
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:27] [INFO] Remaining power left: 183.824982
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:27] [INFO] Selected GPU device 6, subtracted power: 36.126999, inverse device energy used: 16.525452
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:27] [INFO] Remaining power left: 147.697983
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:27] [INFO] Selected GPU device 11, subtracted power: 35.754002, inverse device energy used: 16.251537
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:27] [INFO] Remaining power left: 111.943985
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:27] [INFO] Selected GPU device 5, subtracted power: 39.064999, inverse device energy used: 16.008982
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:27] [INFO] Remaining power left: 72.878983
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:27] [INFO] Selected GPU device 14, subtracted power: 40.154999, inverse device energy used: 12.482958
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:27] [INFO] Remaining power left: 32.723984
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:27] [INFO] All devices are selected and there is still power left: 32.723984
[des06.kask.eti.pg.gda.pl] [Thread 22] [2024-12-09 22:19:27] [INFO] Scaling CPU batch size by 0.690239 (new value: 2208)
[2024-12-09 22:19:27] [INFO] Main elapsed time=0.811342

[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:27] [INFO] Batches sent by thread 0: 82113
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:27] [INFO] Data points processed by thread 0: 262761600
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:27] [INFO] Batches sent by thread 1: 5
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:27] [INFO] Data points processed by thread 1: 16000
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:27] [INFO] Batches sent by thread 2: 8
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:27] [INFO] Data points processed by thread 2: 25600
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:27] [INFO] Batches sent by thread 3: 8
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:27] [INFO] Data points processed by thread 3: 25600
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:27] [INFO] Batches sent by thread 4: 8
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:27] [INFO] Data points processed by thread 4: 25600
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:27] [INFO] Batches sent by thread 5: 2964
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:27] [INFO] Data points processed by thread 5: 9484800
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:27] [INFO] Batches sent by thread 6: 2956
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:27] [INFO] Data points processed by thread 6: 9459200
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:27] [INFO] Batches sent by thread 7: 8
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:27] [INFO] Data points processed by thread 7: 25600
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:27] [INFO] Batches sent by thread 8: 2948
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:27] [INFO] Data points processed by thread 8: 9433600
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:27] [INFO] Batches sent by thread 9: 2956
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:27] [INFO] Data points processed by thread 9: 9459200
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:27] [INFO] Batches sent by thread 10: 16
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:27] [INFO] Data points processed by thread 10: 51200
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:27] [INFO] Batches sent by thread 11: 2888
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:27] [INFO] Data points processed by thread 11: 9241600
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:27] [INFO] Batches sent by thread 12: 8
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:27] [INFO] Data points processed by thread 12: 25600
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:27] [INFO] Batches sent by thread 13: 12
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:27] [INFO] Data points processed by thread 13: 38400
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:27] [INFO] Batches sent by thread 14: 3004
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:27] [INFO] Data points processed by thread 14: 9612800
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:27] [INFO] Batches sent by thread 15: 36
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:27] [INFO] Data points processed by thread 15: 23040
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:27] [INFO] Batches sent by thread 16: 36
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:27] [INFO] Data points processed by thread 16: 23040
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:27] [INFO] Batches sent by thread 17: 32
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:27] [INFO] Data points processed by thread 17: 20480
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:27] [INFO] Batches sent by thread 18: 36
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:27] [INFO] Data points processed by thread 18: 23040
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:27] [INFO] Batches sent by thread 19: 40
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:27] [INFO] Data points processed by thread 19: 25600
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:27] [INFO] Batches sent by thread 20: 32
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:27] [INFO] Data points processed by thread 20: 20480
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:27] [INFO] Batches sent by thread 21: 32
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:27] [INFO] Data points processed by thread 21: 20480
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:27] [INFO] Batches sent by thread 22: 36
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:27] [INFO] Data points processed by thread 22: 23040
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:27] [INFO] Batches sent by thread 23: 36
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:27] [INFO] Data points processed by thread 23: 23040
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:27] [INFO] Batches sent by thread 24: 36
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:27] [INFO] Data points processed by thread 24: 23040
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:27] [INFO] Batches sent by thread 25: 40
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:27] [INFO] Data points processed by thread 25: 25600
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:27] [INFO] Batches sent by thread 26: 36
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:27] [INFO] Data points processed by thread 26: 23040
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:27] [INFO] Batches sent by thread 27: 32
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:27] [INFO] Data points processed by thread 27: 20480
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:27] [INFO] Batches sent by thread 28: 32
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:27] [INFO] Data points processed by thread 28: 20480
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:19:27] [WARN] Terminating CUDAMPILIB, Total energy used 249.637676 J
[2024-12-09 22:19:28] [INFO] Total elapsed time=3.277106
```



```
s184297@des06:~/parallel-processing-cpu-and-gpu-env-and-lib-with-powercap/cudampilib$ ./run_scripts/run-app vecadd B 15 --cpu-enabled=1 --number-of-streams=2   --batch-size=3200 --powercap=10
00 --problem-size=320000000 --initial-cpu-batch-size-scaling 5
All arguments provided:
=====================================
APP_NAME: 'vecadd'
MODE: 'B'
=====================================
MACHINES COUNT: '15'
SLAVE_PROC_AMOUNT: '14'
=====================================
Running master on des01 and slaves on des (2 - 15)
Running remotely with application 'vecadd'...
Command: mpirun --mca orte_keep_fqdn_hostnames t --mca btl_tcp_if_exclude docker0,docker_gwbridge,lo,vboxnet0 --bind-to none --machinefile "./temp_hostfile" -np 1 ./build/app-streams-vecadd --cpu-enabled=1 --number-of-streams=2 --batch-size=3200 --powercap=1000 --problem-size=320000000 --initial-cpu-batch-size-scaling 5 : -np 14 ./build/cudampislave-vecadd
=====================================
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:35] [INFO] CPU Enabled                                : 1
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:35] [INFO] Number of Streams                          : 2
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:35] [INFO] Batch Size                                 : 3200
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:35] [INFO] Power Cap                                  : 1000
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:35] [INFO] Problem Size                               : 320000000
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:35] [INFO] Initial Cpu Batch Size Scaling Factor      : 5
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:35] [INFO] Dynamic CPU Batch Size Scaling Enabled     : 1
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:35] [INFO] Scaled CPU batch size down to 640 from 3200 (factor of 5)
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:35] [INFO] 
Setting power limit=1000

[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:35] [INFO] 
On node 0 using 1 GPUs.
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:35] [INFO] 
On node 0 using 0 CPU threads.

[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:35] [INFO] 
On node 1 using 1 GPUs.
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:35] [INFO] 
On node 1 using 23 CPU threads.

[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:35] [INFO] 
On node 2 using 1 GPUs.
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:35] [INFO] 
On node 2 using 23 CPU threads.

[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:35] [INFO] 
On node 3 using 1 GPUs.
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:35] [INFO] 
On node 3 using 23 CPU threads.

[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:35] [INFO] 
On node 4 using 1 GPUs.
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:35] [INFO] 
On node 4 using 23 CPU threads.

[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:35] [INFO] 
On node 5 using 1 GPUs.
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:35] [INFO] 
On node 5 using 23 CPU threads.

[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:35] [INFO] 
On node 6 using 1 GPUs.
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:35] [INFO] 
On node 6 using 23 CPU threads.

[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:35] [INFO] 
On node 7 using 1 GPUs.
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:35] [INFO] 
On node 7 using 23 CPU threads.

[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:35] [INFO] 
On node 8 using 1 GPUs.
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:35] [INFO] 
On node 8 using 23 CPU threads.

[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:35] [INFO] 
On node 9 using 1 GPUs.
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:35] [INFO] 
On node 9 using 23 CPU threads.

[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:35] [INFO] 
On node 10 using 1 GPUs.
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:35] [INFO] 
On node 10 using 23 CPU threads.

[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:35] [INFO] 
On node 11 using 1 GPUs.
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:35] [INFO] 
On node 11 using 23 CPU threads.

[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:35] [INFO] 
On node 12 using 1 GPUs.
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:35] [INFO] 
On node 12 using 23 CPU threads.

[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:35] [INFO] 
On node 13 using 1 GPUs.
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:35] [INFO] 
On node 13 using 23 CPU threads.

[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:35] [INFO] 
On node 14 using 1 GPUs.
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:35] [INFO] 
On node 14 using 23 CPU threads.

[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Selected GPU device 0, subtracted power: 39.384998, inverse device energy used: 619.277527
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Remaining power left: 960.614990
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Selected GPU device 11, subtracted power: 35.737000, inverse device energy used: 16.411850
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Remaining power left: 924.877991
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Selected GPU device 6, subtracted power: 35.165001, inverse device energy used: 16.231373
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Remaining power left: 889.713013
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Selected GPU device 10, subtracted power: 37.845001, inverse device energy used: 14.259886
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Remaining power left: 851.868042
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Selected GPU device 14, subtracted power: 41.429001, inverse device energy used: 13.808743
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Remaining power left: 810.439026
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Selected GPU device 8, subtracted power: 38.077000, inverse device energy used: 12.260772
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Remaining power left: 772.362000
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Selected GPU device 12, subtracted power: 40.056999, inverse device energy used: 8.451058
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Remaining power left: 732.304993
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Selected GPU device 5, subtracted power: 39.472000, inverse device energy used: 7.764147
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Remaining power left: 692.833008
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Selected GPU device 9, subtracted power: 37.612999, inverse device energy used: 7.719673
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Remaining power left: 655.220032
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Selected GPU device 2, subtracted power: 42.417999, inverse device energy used: 7.401852
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Remaining power left: 612.802002
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Selected GPU device 7, subtracted power: 45.273998, inverse device energy used: 5.803398
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Remaining power left: 567.528015
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Selected GPU device 13, subtracted power: 39.210999, inverse device energy used: 5.369063
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Remaining power left: 528.317017
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Selected CPU device 25, subtracted power: 54.282471, inverse device energy used: 1.969231
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Remaining power left: 474.034546
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Selected GPU device 3, subtracted power: 44.708000, inverse device energy used: 1.910271
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Remaining power left: 429.326538
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Selected GPU device 4, subtracted power: 34.327999, inverse device energy used: 1.796530
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Remaining power left: 394.998535
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Selected CPU device 28, subtracted power: 81.287415, inverse device energy used: 1.402740
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Remaining power left: 313.711121
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Selected CPU device 18, subtracted power: 56.921677, inverse device energy used: 1.280000
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Remaining power left: 256.789429
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Selected CPU device 20, subtracted power: 93.920769, inverse device energy used: 1.163636
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Remaining power left: 162.868652
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Selected CPU device 22, subtracted power: 90.034050, inverse device energy used: 1.163636
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Remaining power left: 72.834602
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Selected CPU device 21, subtracted power: 59.083878, inverse device energy used: 0.581818
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Remaining power left: 13.750725
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] All devices are selected and there is still power left: 13.750725
[des06.kask.eti.pg.gda.pl] [Thread 25] [2024-12-09 22:20:37] [INFO] Scaling CPU batch size by 0.814047 (new value: 2604)
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Selected GPU device 0, subtracted power: 39.384998, inverse device energy used: 222.722610
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Remaining power left: 960.614990
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Selected GPU device 11, subtracted power: 35.737000, inverse device energy used: 16.411850
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Remaining power left: 924.877991
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Selected GPU device 6, subtracted power: 35.165001, inverse device energy used: 16.231373
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Remaining power left: 889.713013
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Selected GPU device 10, subtracted power: 37.845001, inverse device energy used: 14.259886
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Remaining power left: 851.868042
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Selected GPU device 14, subtracted power: 41.429001, inverse device energy used: 13.808743
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Remaining power left: 810.439026
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Selected GPU device 8, subtracted power: 38.077000, inverse device energy used: 12.260772
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Remaining power left: 772.362000
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Selected GPU device 12, subtracted power: 40.056999, inverse device energy used: 8.451058
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Remaining power left: 732.304993
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Selected GPU device 5, subtracted power: 39.472000, inverse device energy used: 7.764147
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Remaining power left: 692.833008
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Selected GPU device 9, subtracted power: 37.612999, inverse device energy used: 7.719673
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Remaining power left: 655.220032
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Selected GPU device 2, subtracted power: 42.417999, inverse device energy used: 7.401852
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Remaining power left: 612.802002
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Selected GPU device 7, subtracted power: 45.273998, inverse device energy used: 5.803398
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Remaining power left: 567.528015
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Selected GPU device 13, subtracted power: 39.210999, inverse device energy used: 5.369063
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Remaining power left: 528.317017
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Selected GPU device 3, subtracted power: 44.708000, inverse device energy used: 1.910271
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Remaining power left: 483.609009
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Selected GPU device 4, subtracted power: 34.327999, inverse device energy used: 1.796530
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Remaining power left: 449.281006
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Selected CPU device 28, subtracted power: 81.287415, inverse device energy used: 1.402740
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Remaining power left: 367.993591
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Selected CPU device 18, subtracted power: 56.921677, inverse device energy used: 1.280000
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Remaining power left: 311.071899
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Selected CPU device 20, subtracted power: 93.920769, inverse device energy used: 1.163636
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Remaining power left: 217.151123
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Selected CPU device 22, subtracted power: 90.034050, inverse device energy used: 1.163636
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Remaining power left: 127.117073
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Selected CPU device 25, subtracted power: 97.760254, inverse device energy used: 1.089362
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Remaining power left: 29.356819
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] All devices are selected and there is still power left: 29.356819
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Selected GPU device 0, subtracted power: 39.384998, inverse device energy used: 668.167847
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Remaining power left: 960.614990
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Selected GPU device 6, subtracted power: 35.165001, inverse device energy used: 17.392883
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Remaining power left: 925.450012
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Selected GPU device 11, subtracted power: 35.737000, inverse device energy used: 16.026463
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Remaining power left: 889.713013
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Selected GPU device 10, subtracted power: 37.845001, inverse device energy used: 14.259886
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Remaining power left: 851.868042
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Selected GPU device 14, subtracted power: 41.429001, inverse device energy used: 13.808743
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Remaining power left: 810.439026
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Selected GPU device 8, subtracted power: 38.077000, inverse device energy used: 12.260772
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Remaining power left: 772.362000
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Selected GPU device 9, subtracted power: 37.612999, inverse device energy used: 7.948148
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Remaining power left: 734.749023
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Selected GPU device 2, subtracted power: 42.417999, inverse device energy used: 7.401852
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Remaining power left: 692.331055
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Selected GPU device 5, subtracted power: 39.472000, inverse device energy used: 6.977255
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Remaining power left: 652.859070
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Selected GPU device 7, subtracted power: 45.273998, inverse device energy used: 5.803398
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Remaining power left: 607.585083
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Selected GPU device 12, subtracted power: 40.056999, inverse device energy used: 5.524325
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Remaining power left: 567.528076
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Selected GPU device 4, subtracted power: 34.327999, inverse device energy used: 5.499479
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Remaining power left: 533.200073
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Selected GPU device 13, subtracted power: 39.210999, inverse device energy used: 5.369063
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Remaining power left: 493.989075
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Selected GPU device 3, subtracted power: 44.708000, inverse device energy used: 1.910271
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Remaining power left: 449.281067
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Selected CPU device 18, subtracted power: 56.921677, inverse device energy used: 1.280000
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Remaining power left: 392.359375
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Selected CPU device 22, subtracted power: 96.940216, inverse device energy used: 1.163636
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Remaining power left: 295.419159
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Selected CPU device 25, subtracted power: 97.760254, inverse device energy used: 1.089362
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Remaining power left: 197.658905
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Selected CPU device 20, subtracted power: 90.057640, inverse device energy used: 1.066667
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Remaining power left: 107.601265
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] All devices are selected and there is still power left: 107.601265
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Selected GPU device 0, subtracted power: 39.603001, inverse device energy used: 615.868591
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Remaining power left: 960.396973
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Selected GPU device 10, subtracted power: 37.858002, inverse device energy used: 16.478163
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Remaining power left: 922.538940
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Selected GPU device 14, subtracted power: 41.429001, inverse device energy used: 14.664447
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Remaining power left: 881.109924
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Selected GPU device 6, subtracted power: 35.165001, inverse device energy used: 10.540166
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Remaining power left: 845.944946
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Selected GPU device 8, subtracted power: 38.077000, inverse device energy used: 10.136076
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Remaining power left: 807.867920
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Selected GPU device 9, subtracted power: 37.641998, inverse device energy used: 9.949840
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Remaining power left: 770.225952
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Selected GPU device 11, subtracted power: 35.762001, inverse device energy used: 9.856412
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Remaining power left: 734.463928
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Selected GPU device 2, subtracted power: 42.417999, inverse device energy used: 8.431651
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Remaining power left: 692.045898
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Selected GPU device 4, subtracted power: 34.327999, inverse device energy used: 6.447707
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Remaining power left: 657.717896
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Selected GPU device 5, subtracted power: 39.472000, inverse device energy used: 6.431687
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Remaining power left: 618.245911
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Selected GPU device 13, subtracted power: 39.216000, inverse device energy used: 6.107736
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Remaining power left: 579.029907
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Selected GPU device 3, subtracted power: 44.708000, inverse device energy used: 6.106296
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Remaining power left: 534.321899
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Selected GPU device 12, subtracted power: 40.056999, inverse device energy used: 5.721848
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Remaining power left: 494.264893
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Selected CPU device 22, subtracted power: 136.612015, inverse device energy used: 3.255000
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Remaining power left: 357.652893
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Selected GPU device 7, subtracted power: 45.277000, inverse device energy used: 2.908767
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Remaining power left: 312.375885
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Selected CPU device 20, subtracted power: 105.022408, inverse device energy used: 2.893333
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Remaining power left: 207.353485
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Selected CPU device 25, subtracted power: 94.019196, inverse device energy used: 2.192842
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] Remaining power left: 113.334290
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:37] [INFO] All devices are selected and there is still power left: 113.334290
[2024-12-09 22:20:38] [INFO] Main elapsed time=1.070704

[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:38] [INFO] Batches sent by thread 0: 81714
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:38] [INFO] Data points processed by thread 0: 261484800
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:38] [INFO] Batches sent by thread 1: 5
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:38] [INFO] Data points processed by thread 1: 16000
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:38] [INFO] Batches sent by thread 2: 1296
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:38] [INFO] Data points processed by thread 2: 4147200
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:38] [INFO] Batches sent by thread 3: 1012
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:38] [INFO] Data points processed by thread 3: 3238400
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:38] [INFO] Batches sent by thread 4: 812
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:38] [INFO] Data points processed by thread 4: 2598400
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:38] [INFO] Batches sent by thread 5: 740
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:38] [INFO] Data points processed by thread 5: 2368000
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:38] [INFO] Batches sent by thread 6: 1260
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:38] [INFO] Data points processed by thread 6: 4032000
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:38] [INFO] Batches sent by thread 7: 924
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:38] [INFO] Data points processed by thread 7: 2956800
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:38] [INFO] Batches sent by thread 8: 1288
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:38] [INFO] Data points processed by thread 8: 4121600
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:38] [INFO] Batches sent by thread 9: 1244
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:38] [INFO] Data points processed by thread 9: 3980800
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:38] [INFO] Batches sent by thread 10: 1940
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:38] [INFO] Data points processed by thread 10: 6208000
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:38] [INFO] Batches sent by thread 11: 1244
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:38] [INFO] Data points processed by thread 11: 3980800
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:38] [INFO] Batches sent by thread 12: 464
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:38] [INFO] Data points processed by thread 12: 1484800
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:38] [INFO] Batches sent by thread 13: 988
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:38] [INFO] Data points processed by thread 13: 3161600
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:38] [INFO] Batches sent by thread 14: 1960
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:38] [INFO] Data points processed by thread 14: 6272000
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:38] [INFO] Batches sent by thread 15: 40
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:38] [INFO] Data points processed by thread 15: 25600
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:38] [INFO] Batches sent by thread 16: 40
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:38] [INFO] Data points processed by thread 16: 25600
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:38] [INFO] Batches sent by thread 17: 40
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:38] [INFO] Data points processed by thread 17: 25600
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:38] [INFO] Batches sent by thread 18: 71
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:38] [INFO] Data points processed by thread 18: 98468
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:38] [INFO] Batches sent by thread 19: 44
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:38] [INFO] Data points processed by thread 19: 28160
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:38] [INFO] Batches sent by thread 20: 1256
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:38] [INFO] Data points processed by thread 20: 3168496
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:38] [INFO] Batches sent by thread 21: 36
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:38] [INFO] Data points processed by thread 21: 23040
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:38] [INFO] Batches sent by thread 22: 1280
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:38] [INFO] Data points processed by thread 22: 3238848
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:38] [INFO] Batches sent by thread 23: 48
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:38] [INFO] Data points processed by thread 23: 30720
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:38] [INFO] Batches sent by thread 24: 52
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:38] [INFO] Data points processed by thread 24: 33280
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:38] [INFO] Batches sent by thread 25: 1248
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:38] [INFO] Data points processed by thread 25: 3155520
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:38] [INFO] Batches sent by thread 26: 44
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:38] [INFO] Data points processed by thread 26: 28160
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:38] [INFO] Batches sent by thread 27: 40
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:38] [INFO] Data points processed by thread 27: 25600
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:38] [INFO] Batches sent by thread 28: 59
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:38] [INFO] Data points processed by thread 28: 43652
[des06.kask.eti.pg.gda.pl] [Thread 0] [2024-12-09 22:20:38] [WARN] Terminating CUDAMPILIB, Total energy used 720.042371 J
[2024-12-09 22:20:38] [INFO] Total elapsed time=3.527224
```


