### PR TITLE
Add configurable power capping strategy loader

### DIFF
--- a/cudampilib/compile
+++ b/cudampilib/compile
@@ -14,8 +14,9 @@ GENERIC_FLAGS="-I/usr/local/cuda-13.0/targets/x86_64-linux/include -Iinclude -L/
 
 mkdir -p $BUILD_DIR
 
-mpicc -fopenmp -c cudampicommon.c -I/usr/local/cuda-13.0/targets/x86_64-linux/include -Iinclude -o $BUILD_DIR/cudampicommon.o 
+mpicc -fopenmp -c cudampicommon.c -I/usr/local/cuda-13.0/targets/x86_64-linux/include -Iinclude -o $BUILD_DIR/cudampicommon.o
 mpicc -fopenmp -c cudampilib.c -I/usr/local/cuda-13.0/targets/x86_64-linux/include -Iinclude -o $BUILD_DIR/cudampilib.o
+mpicc -fopenmp -c powercap_config.c -I/usr/local/cuda-13.0/targets/x86_64-linux/include -Iinclude -o $BUILD_DIR/powercap_config.o
 
 #nvcc -c $APPS_DIR/$APP_DIR/appkernel.cu -o $BUILD_DIR/appkernel.o
 nvcc -c $APPS_DIR/$VECMAXDIV_DIR/appkernelvecmaxdiv.cu -o $BUILD_DIR/appkernelvecmaxdiv.o -Iinclude
@@ -35,20 +36,20 @@ mpicc -fopenmp -c $APPS_DIR/$RNN_DIR/cpukernelrnn.c -Iinclude -I/opt/intel/oneap
 
 
 #mpicc -fopenmp -o $BUILD_DIR/cudampislave cudampislave.c $BUILD_DIR/appkernel.o $BUILD_DIR/cudampicommon.o -I/usr/local/cuda-13.0/targets/x86_64-linux/include -Iinclude -L/usr/local/cuda-13.0/targets/x86_64-linux/lib -lcudart -lstdc++
-mpicc -fopenmp -o $BUILD_DIR/cudampislave-vecmaxdiv cudampislave.c $BUILD_DIR/cpukernelvecmaxdiv.o $BUILD_DIR/appkernelvecmaxdiv.o $BUILD_DIR/cudampicommon.o $GENERIC_FLAGS
-mpicc -fopenmp -o $BUILD_DIR/cudampislave-vecadd cudampislave.c $BUILD_DIR/cpukernelvecadd.o $BUILD_DIR/appkernelvecadd.o $BUILD_DIR/cudampicommon.o $GENERIC_FLAGS
-mpicc -fopenmp -o $BUILD_DIR/cudampislave-collatz cudampislave.c $BUILD_DIR/cpukernelcollatz.o $BUILD_DIR/appkernelcollatz.o $BUILD_DIR/cudampicommon.o $GENERIC_FLAGS
-mpicc -fopenmp -o $BUILD_DIR/cudampislave-patternsearch cudampislave.c $BUILD_DIR/cpukernelpatternsearch.o $BUILD_DIR/appkernelpatternsearch.o $BUILD_DIR/cudampicommon.o $GENERIC_FLAGS
-mpicc -fopenmp -o $BUILD_DIR/cudampislave-twinprime cudampislave.c $BUILD_DIR/cpukerneltwinprime.o $BUILD_DIR/appkerneltwinprime.o $BUILD_DIR/cudampicommon.o $GENERIC_FLAGS
-mpicc -fopenmp -o $BUILD_DIR/cudampislave-rnn cudampislave.c $BUILD_DIR/cpukernelrnn.o $BUILD_DIR/appkernelrnn.o $BUILD_DIR/cudampicommon.o $GENERIC_FLAGS -lcublas -I/opt/intel/oneapi/mkl/latest/include -L/opt/intel/oneapi/mkl/latest/lib/intel64 -Wl,-Bstatic -lmkl_intel_lp64 -lmkl_gnu_thread -lmkl_core -Wl,-Bdynamic -lpthread -lm
+mpicc -fopenmp -o $BUILD_DIR/cudampislave-vecmaxdiv cudampislave.c $BUILD_DIR/cpukernelvecmaxdiv.o $BUILD_DIR/appkernelvecmaxdiv.o $BUILD_DIR/cudampicommon.o $BUILD_DIR/powercap_config.o $GENERIC_FLAGS
+mpicc -fopenmp -o $BUILD_DIR/cudampislave-vecadd cudampislave.c $BUILD_DIR/cpukernelvecadd.o $BUILD_DIR/appkernelvecadd.o $BUILD_DIR/cudampicommon.o $BUILD_DIR/powercap_config.o $GENERIC_FLAGS
+mpicc -fopenmp -o $BUILD_DIR/cudampislave-collatz cudampislave.c $BUILD_DIR/cpukernelcollatz.o $BUILD_DIR/appkernelcollatz.o $BUILD_DIR/cudampicommon.o $BUILD_DIR/powercap_config.o $GENERIC_FLAGS
+mpicc -fopenmp -o $BUILD_DIR/cudampislave-patternsearch cudampislave.c $BUILD_DIR/cpukernelpatternsearch.o $BUILD_DIR/appkernelpatternsearch.o $BUILD_DIR/cudampicommon.o $BUILD_DIR/powercap_config.o $GENERIC_FLAGS
+mpicc -fopenmp -o $BUILD_DIR/cudampislave-twinprime cudampislave.c $BUILD_DIR/cpukerneltwinprime.o $BUILD_DIR/appkerneltwinprime.o $BUILD_DIR/cudampicommon.o $BUILD_DIR/powercap_config.o $GENERIC_FLAGS
+mpicc -fopenmp -o $BUILD_DIR/cudampislave-rnn cudampislave.c $BUILD_DIR/cpukernelrnn.o $BUILD_DIR/appkernelrnn.o $BUILD_DIR/cudampicommon.o $BUILD_DIR/powercap_config.o $GENERIC_FLAGS -lcublas -I/opt/intel/oneapi/mkl/latest/include -L/opt/intel/oneapi/mkl/latest/lib/intel64 -Wl,-Bstatic -lmkl_intel_lp64 -lmkl_gnu_thread -lmkl_core -Wl,-Bdynamic -lpthread -lm
 
 
 #mpicc -fopenmp -o $BUILD_DIR/app $APPS_DIR/$APP_DIR/app.c $BUILD_DIR/appkernel.o $BUILD_DIR/cudampilib.o $BUILD_DIR/cudampicommon.o -I/usr/local/cuda-13.0/targets/x86_64-linux/include -Iinclude -L/usr/local/cuda-13.0/targets/x86_64-linux/lib -lcudart -lstdc++
-mpicc -fopenmp -o $BUILD_DIR/app-streams-vecmaxdiv $APPS_DIR/$VECMAXDIV_DIR/app-streams-vecmaxdiv.c $BUILD_DIR/cpukernelvecmaxdiv.o $BUILD_DIR/appkernelvecmaxdiv.o $BUILD_DIR/cudampilib.o $BUILD_DIR/cudampicommon.o $GENERIC_FLAGS
-mpicc -fopenmp -o $BUILD_DIR/app-streams-vecadd $APPS_DIR/$VECADD_DIR/app-streams-vecadd.c $BUILD_DIR/cpukernelvecadd.o $BUILD_DIR/appkernelvecadd.o $BUILD_DIR/cudampilib.o $BUILD_DIR/cudampicommon.o $GENERIC_FLAGS
-mpicc -fopenmp -o $BUILD_DIR/app-streams-collatz $APPS_DIR/$COLLATZ_DIR/app-streams-collatz.c $BUILD_DIR/cpukernelcollatz.o $BUILD_DIR/appkernelcollatz.o $BUILD_DIR/cudampilib.o $BUILD_DIR/cudampicommon.o $GENERIC_FLAGS
-mpicc -fopenmp -o $BUILD_DIR/app-streams-patternsearch $APPS_DIR/$PATTERNSEARCH_DIR/app-streams-patternsearch.c $BUILD_DIR/cpukernelpatternsearch.o $BUILD_DIR/appkernelpatternsearch.o $BUILD_DIR/cudampilib.o $BUILD_DIR/cudampicommon.o $GENERIC_FLAGS
-mpicc -fopenmp -o $BUILD_DIR/app-streams-twinprime $APPS_DIR/$TWINPRIME_DIR/app-streams-twinprime.c $BUILD_DIR/cpukerneltwinprime.o $BUILD_DIR/appkerneltwinprime.o $BUILD_DIR/cudampilib.o $BUILD_DIR/cudampicommon.o $GENERIC_FLAGS
-mpicc -fopenmp -o $BUILD_DIR/app-streams-rnn $APPS_DIR/$RNN_DIR/app-streams-rnn.c $BUILD_DIR/cpukernelrnn.o $BUILD_DIR/appkernelrnn.o $BUILD_DIR/cudampilib.o $BUILD_DIR/cudampicommon.o $GENERIC_FLAGS -lcublas -I/opt/intel/oneapi/mkl/latest/include -L/opt/intel/oneapi/mkl/latest/lib/intel64 -Wl,-Bstatic -lmkl_intel_lp64 -lmkl_gnu_thread -lmkl_core -Wl,-Bdynamic -lpthread -lm
+mpicc -fopenmp -o $BUILD_DIR/app-streams-vecmaxdiv $APPS_DIR/$VECMAXDIV_DIR/app-streams-vecmaxdiv.c $BUILD_DIR/cpukernelvecmaxdiv.o $BUILD_DIR/appkernelvecmaxdiv.o $BUILD_DIR/cudampilib.o $BUILD_DIR/cudampicommon.o $BUILD_DIR/powercap_config.o $GENERIC_FLAGS
+mpicc -fopenmp -o $BUILD_DIR/app-streams-vecadd $APPS_DIR/$VECADD_DIR/app-streams-vecadd.c $BUILD_DIR/cpukernelvecadd.o $BUILD_DIR/appkernelvecadd.o $BUILD_DIR/cudampilib.o $BUILD_DIR/cudampicommon.o $BUILD_DIR/powercap_config.o $GENERIC_FLAGS
+mpicc -fopenmp -o $BUILD_DIR/app-streams-collatz $APPS_DIR/$COLLATZ_DIR/app-streams-collatz.c $BUILD_DIR/cpukernelcollatz.o $BUILD_DIR/appkernelcollatz.o $BUILD_DIR/cudampilib.o $BUILD_DIR/cudampicommon.o $BUILD_DIR/powercap_config.o $GENERIC_FLAGS
+mpicc -fopenmp -o $BUILD_DIR/app-streams-patternsearch $APPS_DIR/$PATTERNSEARCH_DIR/app-streams-patternsearch.c $BUILD_DIR/cpukernelpatternsearch.o $BUILD_DIR/appkernelpatternsearch.o $BUILD_DIR/cudampilib.o $BUILD_DIR/cudampicommon.o $BUILD_DIR/powercap_config.o $GENERIC_FLAGS
+mpicc -fopenmp -o $BUILD_DIR/app-streams-twinprime $APPS_DIR/$TWINPRIME_DIR/app-streams-twinprime.c $BUILD_DIR/cpukerneltwinprime.o $BUILD_DIR/appkerneltwinprime.o $BUILD_DIR/cudampilib.o $BUILD_DIR/cudampicommon.o $BUILD_DIR/powercap_config.o $GENERIC_FLAGS
+mpicc -fopenmp -o $BUILD_DIR/app-streams-rnn $APPS_DIR/$RNN_DIR/app-streams-rnn.c $BUILD_DIR/cpukernelrnn.o $BUILD_DIR/appkernelrnn.o $BUILD_DIR/cudampilib.o $BUILD_DIR/cudampicommon.o $BUILD_DIR/powercap_config.o $GENERIC_FLAGS -lcublas -I/opt/intel/oneapi/mkl/latest/include -L/opt/intel/oneapi/mkl/latest/lib/intel64 -Wl,-Bstatic -lmkl_intel_lp64 -lmkl_gnu_thread -lmkl_core -Wl,-Bdynamic -lpthread -lm
 
 echo "Build complete. Executables and object files are in '$BUILD_DIR'."

--- a/cudampilib/cudampicommon.c
+++ b/cudampilib/cudampicommon.c
@@ -104,20 +104,20 @@ powercapRange_t __cudampi__getCpuPowerCapRange()
   file = fopen("/sys/class/powercap/intel-rapl:0/constraint_0_time_window_us", "r");
   if (file == NULL) {
     log_message(LOG_ERROR, "Failed to open constraint_0_time_window_us file for reading");
-    range.timeWindowUs = -1;
+    range.defaultTimeWindowUs = -1;
     return range;
   }
 
   if (fscanf(file, "%llu", &timeWindow_us) != 1) {
     log_message(LOG_ERROR, "Failed to read time window value");
     fclose(file);
-    range.timeWindowUs = -1;
+    range.defaultTimeWindowUs = -1;
     return range;
   }
 
   fclose(file);
 
-  range.timeWindowUs = timeWindow_us;
+  range.defaultTimeWindowUs = timeWindow_us;
 
   return range;
 }
@@ -246,7 +246,6 @@ int socketSetGpuPowerCap(int gpuid, float powerCap)
 
 void __cudampi__setGpuPowerCap(int gpuid, float powerCap)
 {
-  log_message(LOG_INFO, "Setting GPU%d power cap to %f W with time window", gpuid, powerCap);
   if (socketSetGpuPowerCap(gpuid, powerCap) == 1) {
     nvmlSetGpuPowerCap(gpuid, powerCap);
   }

--- a/cudampilib/cudampilib.c
+++ b/cudampilib/cudampilib.c
@@ -128,8 +128,6 @@ static struct argp_option options[] = {
   { "cpu-power-scaling",                 's',  "SCALING FACTOR",    0, "Set the CPU power scaling factor" },
   { "initial-cpu-batch-size-scaling",    'f',  "SCALING FACTOR",    0, "Set initial scaling factor for CPU batch size (0 to disable)" },
   { "disable-dynamic-cpu-batch-scaling",  0,    0,                  0, "Disable dynamic CPU batch size scaling" },
-  { "cpu-min-powercap", 'x', "PART OF RANGE", 0, "Set minimum CPU power cap expressed as point on range from min to max" },
-  { "gpu-min-powercap", 'y', "PART OF RANGE", 0, "Set minimum GPU power cap expressed as point on range from min to max" },
   { 0 }
 };
 
@@ -1105,11 +1103,7 @@ void __cudampi__initializeMPI(int argc, char **argv) {
   log_message(LOG_INFO, "CPU Power Scaling                          : %f",   __cudampi__arguments.cpu_power_scaling);
   log_message(LOG_INFO, "Initial Cpu Batch Size Scaling Factor      : %d",   __cudampi__arguments.cpu_batch_scaling_factor);
   log_message(LOG_INFO, "Dynamic CPU Batch Size Scaling Enabled     : %d",   __cudampi__arguments.use_dynamic_scaling);
-  log_message(LOG_INFO, "Min CPU Power Cap                          : %f",   __cudampi__arguments.cpu_min_powercap);
-  log_message(LOG_INFO, "Min GPU Power Cap                          : %f",   __cudampi__arguments.gpu_min_powercap);
 
-  __cudampi__cpu_min_powercap = __cudampi__arguments.cpu_min_powercap;
-  __cudampi__gpu_min_powercap = __cudampi__arguments.gpu_min_powercap;
   __cudampi__dyanmicCpuBatchSizeScalingEnabled = __cudampi__arguments.use_dynamic_scaling;
   __cudampi__cpu_enabled = __cudampi__arguments.cpu_enabled;
   __cudampi__default_batch_size = __cudampi__arguments.batch_size;
@@ -1124,9 +1118,30 @@ void __cudampi__initializeMPI(int argc, char **argv) {
       __cudampi__cpu_min_powercap = file_config.cpu_min_powercap;
       __cudampi__gpu_min_powercap = file_config.gpu_min_powercap;
     } else if (file_config.strategy == EDP_GRADIENT_OPT) {
-      __cudampi__globalpowerlimit = file_config.start_powercap;
+      __cudampi__globalpowerlimit = 0;
       __cudampi__isglobalpowerlimitset = 1;
     }
+  }
+  else {
+    __cudampi__powercapStrategy = BINARY_GREEDY;
+  }
+
+  // Print selected powercap strategy and, for continuous strategy, print min powercap parts
+  switch (__cudampi__powercapStrategy) {
+    case BINARY_GREEDY:
+      log_message(LOG_INFO, "Powercap strategy: BINARY_GREEDY");
+      break;
+    case CONTINOUS_EQUAL:
+      log_message(LOG_INFO, "Powercap strategy: CONTINOUS_EQUAL");
+      log_message(LOG_INFO, "CPU min powercap (part of range): %f", __cudampi__cpu_min_powercap);
+      log_message(LOG_INFO, "GPU min powercap (part of range): %f", __cudampi__gpu_min_powercap);
+      break;
+    case EDP_GRADIENT_OPT:
+      log_message(LOG_INFO, "Powercap strategy: EDP_GRADIENT_OPT");
+      break;
+    default:
+      log_message(LOG_INFO, "Powercap strategy: UNKNOWN (%d)", __cudampi__powercapStrategy);
+      break;
   }
 
   if (__cudampi__cpu_enabled == 0)
@@ -1161,11 +1176,6 @@ void __cudampi__initializeMPI(int argc, char **argv) {
   if (__cudampi__arguments.powercap > 0) {
     log_message(LOG_INFO, "\nSetting power limit=%d\n", __cudampi__arguments.powercap);
     __cudampi__setglobalpowerlimit(__cudampi__arguments.powercap);
-  }
-
-  if (__cudampi__powercapStrategy == EDP_GRADIENT_OPT && !__cudampi__isglobalpowerlimitset) {
-    __cudampi__isglobalpowerlimitset = 1;
-    __cudampi__globalpowerlimit = 0;
   }
 
   // fetch information about the rank and number of processes
@@ -1461,7 +1471,7 @@ void __cudampi__terminateMPI() {
 
   if (__cudampi__isglobalpowerlimitset) {
     // Reset CPU power cap
-    __cudampi__setCpuPowerCap(__cudampi__localPowerCapRange.cpuRange.defaultPowerCap, __cudampi__localPowerCapRange.cpuRange.timeWindowUs);
+    __cudampi__setCpuPowerCap(__cudampi__localPowerCapRange.cpuRange.defaultPowerCap, __cudampi__localPowerCapRange.cpuRange.defaultTimeWindowUs);
     // Reset GPU power caps
     for (int i = 0; i < __cudampi__localGpuDeviceCount; i++) {
       __cudampi__setGpuPowerCap(i, __cudampi__localPowerCapRange.gpuRange[i].defaultPowerCap);

--- a/cudampilib/cudampilib.c
+++ b/cudampilib/cudampilib.c
@@ -25,6 +25,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OU
 
 #include "cudampicommon.h"
 #include "cudampilib.h"
+#include "powercap_config.h"
 
 // int __cudampi__GPUcountpernode=1;
 
@@ -1114,7 +1115,20 @@ void __cudampi__initializeMPI(int argc, char **argv) {
   __cudampi__default_batch_size = __cudampi__arguments.batch_size;
 
   __cudampi__cpu_power_scaling = __cudampi__arguments.cpu_power_scaling;
-  
+
+  // Load power capping configuration from file if available
+  powercap_config_t file_config;
+  if (load_powercap_config("powercap.conf", &file_config) == 0) {
+    __cudampi__powercapStrategy = file_config.strategy;
+    if (file_config.strategy == CONTINOUS_EQUAL) {
+      __cudampi__cpu_min_powercap = file_config.cpu_min_powercap;
+      __cudampi__gpu_min_powercap = file_config.gpu_min_powercap;
+    } else if (file_config.strategy == EDP_GRADIENT_OPT) {
+      __cudampi__globalpowerlimit = file_config.start_powercap;
+      __cudampi__isglobalpowerlimitset = 1;
+    }
+  }
+
   if (__cudampi__cpu_enabled == 0)
   {
     log_message(LOG_INFO, "Cpu disabled. Setting CPU power scaling to 0.0");
@@ -1149,7 +1163,7 @@ void __cudampi__initializeMPI(int argc, char **argv) {
     __cudampi__setglobalpowerlimit(__cudampi__arguments.powercap);
   }
 
-  if (__cudampi__powercapStrategy == EDP_GRADIENT_OPT) {
+  if (__cudampi__powercapStrategy == EDP_GRADIENT_OPT && !__cudampi__isglobalpowerlimitset) {
     __cudampi__isglobalpowerlimitset = 1;
     __cudampi__globalpowerlimit = 0;
   }

--- a/cudampilib/cudampislave.c
+++ b/cudampilib/cudampislave.c
@@ -1217,7 +1217,7 @@ int main(int argc, char **argv) {
   }
   
   // Reset CPU power cap
-  __cudampi__setCpuPowerCap(__cudampi__localPowerCapRange.cpuRange.defaultPowerCap, __cudampi__localPowerCapRange.cpuRange.timeWindowUs);
+  __cudampi__setCpuPowerCap(__cudampi__localPowerCapRange.cpuRange.defaultPowerCap, __cudampi__localPowerCapRange.cpuRange.defaultTimeWindowUs);
   // Reset GPU power caps
   for (int i = 0; i < __cudampi__localGpuDeviceCount; i++) {
     __cudampi__setGpuPowerCap(i, __cudampi__localPowerCapRange.gpuRange[i].defaultPowerCap);

--- a/cudampilib/include/cudampilib.h
+++ b/cudampilib/include/cudampilib.h
@@ -9,12 +9,13 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
+#ifndef CUDAMPILIB_H
+#define CUDAMPILIB_H
+
 #include "cudampi.h"
 #include <cuda_runtime.h>
 #include <mpi.h>
 
-
-#define START_POWERCAP_FOR_GRAD_OPT 1.0
 
 typedef enum {
   CONTINOUS_EQUAL,
@@ -121,3 +122,5 @@ cudaError_t __cudampi__memcpy(void *dst, const void *src, size_t count, enum cud
 void __cudampi__kernelInStream(void *devPtr, cudaStream_t stream, unsigned long long id);
 
 void __cudampi__kernel(void *devPtr, unsigned long long id);
+
+#endif

--- a/cudampilib/include/powercap_config.h
+++ b/cudampilib/include/powercap_config.h
@@ -1,0 +1,21 @@
+#ifndef POWERCAP_CONFIG_H
+#define POWERCAP_CONFIG_H
+
+#include "cudampilib.h"
+
+// Structure holding power capping configuration
+// Additional fields can be easily added to this structure
+// to extend configuration options.
+typedef struct {
+    powercapStrategy_t strategy; // selected power capping strategy
+    float cpu_min_powercap;      // minimum CPU power cap (for continuous strategy)
+    float gpu_min_powercap;      // minimum GPU power cap (for continuous strategy)
+    float start_powercap;        // starting power cap (for gradient optimization)
+} powercap_config_t;
+
+// Loads configuration from a simple key=value file.
+// Unknown keys are ignored to keep the parser easily extendable.
+// If the file cannot be read, the structure is left with default values.
+int load_powercap_config(const char *path, powercap_config_t *config);
+
+#endif // POWERCAP_CONFIG_H

--- a/cudampilib/powercap.conf
+++ b/cudampilib/powercap.conf
@@ -1,0 +1,8 @@
+# Example power capping configuration
+# strategy can be CONTINOUS_EQUAL, BINARY_GREEDY or EDP_GRADIENT_OPT
+strategy=BINARY_GREEDY
+# cpu_min_powercap and gpu_min_powercap are used for CONTINOUS_EQUAL strategy
+cpu_min_powercap=0.0
+gpu_min_powercap=0.0
+# start_powercap is used for EDP_GRADIENT_OPT strategy
+start_powercap=1.0

--- a/cudampilib/powercap.conf
+++ b/cudampilib/powercap.conf
@@ -1,8 +1,8 @@
 # Example power capping configuration
 # strategy can be CONTINOUS_EQUAL, BINARY_GREEDY or EDP_GRADIENT_OPT
-strategy=BINARY_GREEDY
+strategy=CONTINOUS_EQUAL
 # cpu_min_powercap and gpu_min_powercap are used for CONTINOUS_EQUAL strategy
-cpu_min_powercap=0.0
-gpu_min_powercap=0.0
+cpu_min_powercap=0.1
+gpu_min_powercap=0.1
 # start_powercap is used for EDP_GRADIENT_OPT strategy
 start_powercap=1.0

--- a/cudampilib/powercap_config.c
+++ b/cudampilib/powercap_config.c
@@ -19,9 +19,9 @@ int load_powercap_config(const char *path, powercap_config_t *config) {
 
     // Default values
     config->strategy = BINARY_GREEDY;
-    config->cpu_min_powercap = 0.0f;
-    config->gpu_min_powercap = 0.0f;
-    config->start_powercap = START_POWERCAP_FOR_GRAD_OPT;
+    config->cpu_min_powercap = 0.0;
+    config->gpu_min_powercap = 0.0;
+    config->start_powercap = 0.5;
 
     FILE *f = fopen(path, "r");
     if (!f) {

--- a/cudampilib/powercap_config.c
+++ b/cudampilib/powercap_config.c
@@ -1,0 +1,62 @@
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <ctype.h>
+
+#include "powercap_config.h"
+
+static void trim(char *str) {
+    char *end;
+    while (isspace((unsigned char)*str)) str++;
+    if (*str == 0) return;
+    end = str + strlen(str) - 1;
+    while (end > str && isspace((unsigned char)*end)) end--;
+    end[1] = '\0';
+}
+
+int load_powercap_config(const char *path, powercap_config_t *config) {
+    if (!config) return -1;
+
+    // Default values
+    config->strategy = BINARY_GREEDY;
+    config->cpu_min_powercap = 0.0f;
+    config->gpu_min_powercap = 0.0f;
+    config->start_powercap = START_POWERCAP_FOR_GRAD_OPT;
+
+    FILE *f = fopen(path, "r");
+    if (!f) {
+        return -1; // silently ignore missing file
+    }
+
+    char line[256];
+    while (fgets(line, sizeof(line), f)) {
+        char *comment = strchr(line, '#');
+        if (comment) *comment = '\0';
+        trim(line);
+        if (strlen(line) == 0) continue;
+
+        char key[128];
+        char value[128];
+        if (sscanf(line, "%127[^=]=%127s", key, value) == 2) {
+            if (strcmp(key, "strategy") == 0) {
+                if (strcmp(value, "CONTINOUS_EQUAL") == 0) {
+                    config->strategy = CONTINOUS_EQUAL;
+                } else if (strcmp(value, "BINARY_GREEDY") == 0) {
+                    config->strategy = BINARY_GREEDY;
+                } else if (strcmp(value, "EDP_GRADIENT_OPT") == 0) {
+                    config->strategy = EDP_GRADIENT_OPT;
+                }
+            } else if (strcmp(key, "cpu_min_powercap") == 0) {
+                config->cpu_min_powercap = (float)atof(value);
+            } else if (strcmp(key, "gpu_min_powercap") == 0) {
+                config->gpu_min_powercap = (float)atof(value);
+            } else if (strcmp(key, "start_powercap") == 0) {
+                config->start_powercap = (float)atof(value);
+            }
+            // Unknown keys are ignored to keep parser extendable
+        }
+    }
+    fclose(f);
+    return 0;
+}
+


### PR DESCRIPTION
## Summary
- add power cap configuration loader and sample config file
- load powercap strategy and parameters from powercap.conf
- compile and link new configuration module

## Testing
- `gcc -c cudampilib/powercap_config.c -I cudampilib/include` *(fails: cuda_runtime.h: No such file or directory)*
- `bash cudampilib/compile` *(fails: mpicc: command not found, nvcc: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b80b0f1324832bbedd51bd10ff188c